### PR TITLE
Install webpack babel react redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An intelligent, group-oriented decision-making travel app to help find places th
 
 ## Usage
 
-> Some usage instructions
+Run `webpack` in the root to start the app in dev mode. Run `NODE_ENV=production webpack` to start the app in production mode.
 
 ## Requirements
 
@@ -116,9 +116,7 @@ Root
 From within the root directory:
 
 ```sh
-sudo npm install -g bower
 npm install
-bower install
 ```
 
 ### Roadmap

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/vivacioustoaster/vivacioustoaster#readme",
   "dependencies": {
+    "react": "^0.14.7",
     "webpack": "^1.12.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "homepage": "https://github.com/vivacioustoaster/vivacioustoaster#readme",
   "dependencies": {
     "react": "^0.14.7",
+    "react-redux": "^4.4.1",
+    "redux": "^3.3.1",
     "webpack": "^1.12.14"
   },
   "devDependencies": {
@@ -32,6 +34,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.5.0"
+    "babel-preset-stage-0": "^6.5.0",
+    "redux-devtools": "^3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vivacioustoaster",
+  "version": "1.0.0",
+  "description": "Group travel made easy",
+  "main": "webpack.config.js",
+  "scripts": {
+    "test": "npm test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vivacioustoaster/vivacioustoaster.git"
+  },
+  "keywords": [
+    "travel"
+  ],
+  "author": "Akshay Buddiga, Jing Lu, Boya Jiang, Leran Firer",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/vivacioustoaster/vivacioustoaster/issues"
+  },
+  "homepage": "https://github.com/vivacioustoaster/vivacioustoaster#readme",
+  "dependencies": {
+    "webpack": "^1.12.14"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "react": "^0.14.7",
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
-    "webpack": "^1.12.14"
-  },
-  "devDependencies": {
     "babel-core": "^6.7.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.1.2",
@@ -35,6 +32,9 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "webpack": "^1.12.14"
+  },
+  "devDependencies": {
     "redux-devtools": "^3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   },
   "homepage": "https://github.com/vivacioustoaster/vivacioustoaster#readme",
   "dependencies": {
-    "react": "^0.14.7",
-    "react-redux": "^4.4.1",
-    "redux": "^3.3.1",
     "babel-core": "^6.7.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.1.2",
@@ -32,6 +29,10 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "react": "^0.14.7",
+    "react-redux": "^4.4.1",
+    "react-router": "^2.0.1",
+    "redux": "^3.3.1",
     "webpack": "^1.12.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,16 @@
   "homepage": "https://github.com/vivacioustoaster/vivacioustoaster#readme",
   "dependencies": {
     "webpack": "^1.12.14"
+  },
+  "devDependencies": {
+    "babel-core": "^6.7.2",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-react-html-attrs": "^2.0.0",
+    "babel-plugin-transform-class-properties": "^6.6.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,17 @@
+var debug = process.env.NODE_ENV !== "production";
+var webpack = require('webpack');
+
+module.exports = {
+  context: __dirname+"/client",
+  devtool: debug ? "inline-sourcemap" : null,
+  entry: "./client/scripts.js",
+  output: {
+    path: __dirname + "/client/dist/js",
+    filename: "scripts.min.js"
+  },
+  plugins: debug ? [] : [
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.optimize.UglifyJsPlugin({ mangle: false, sourcemap: false }),
+  ],
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,26 @@
 var debug = process.env.NODE_ENV !== "production";
 var webpack = require('webpack');
+var path = require('path');
 
 module.exports = {
-  context: __dirname+"/client",
+  context: path.join(__dirname, "client"),
   devtool: debug ? "inline-sourcemap" : null,
-  entry: "./client/scripts.js",
+  entry: "./scripts.js",
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: /(node_modules|bower_components)/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['react', 'es2015', 'stage-0'],
+          plugins: ['react-html-attrs', 'transform-class-properties', 'transform-decorators-legacy'],
+        }
+      }
+    ]
+  },
   output: {
-    path: __dirname + "/client/dist/js",
+    path: __dirname + "/client/",
     filename: "scripts.min.js"
   },
   plugins: debug ? [] : [


### PR DESCRIPTION
#### What's this PR do?

Installs the following dependencies:
- React
- Redux
- React-redux
- redux-devtools
- React-router
- webpack
- Babel and associated plugins (ES2015, React, Stage-0 for ES7 features)

It also sets up the `webpack.config.js` file. This currently assumes that client-side code lives in a file called `scripts.js` inside the `client` folder in the root. We can either create this file and require all the other js files inside it, or we can change this entry point later.
Currently, webpack will run the combined code in `scripts.js` through the Babel transpiler, minify it, and put it in a new file called `scripts.min.js`. This file is required within our html file.
#### Any background context you want to provide?

Run `npm install` to install dependencies. To start the app in dev mode, run `webpack`. To start in production mode, run `NODE_ENV=production webpack`.
#### What are the relevant tickets/issues?

Closes #51 
#### Where should the reviewer start?

`package.json`, then review webpack config.
#### Are there tests written yet? How should this be manually tested?

Run `webpack` after the client folder and `scripts.js` file have been created.
#### Screenshots (if appropriate)
#### Questions:
- Does this add new dependencies?
  Yes, see above.
- Does our documentation need to be updated?
  Yes, running the app is now done through webpack commands. Updated README.
