### PR TITLE
Set port using process.env

### DIFF
--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -1,7 +1,7 @@
 const morgan = require('morgan');
 const bodyParser = require('body-parser');
 
-module.exports = function (app, express) {
+module.exports = (app, express) => {
   app.use(morgan('dev'));
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -1,4 +1,4 @@
-module.exports = function (app, express) {
+module.exports = (app, express) => {
   app.get('/auth/facebook'/* , controller function here */);
   app.get('/auth/facebook/callback'/* , controller function here */);
   app.get('api/me'/* , controller function here */);

--- a/server/server.js
+++ b/server/server.js
@@ -7,5 +7,6 @@ require('./config/routes.js')(app, express);
 
 app.set('port', PORT);
 app.listen(PORT);
+console.log(`Listening on port ${app.get('port')}`);
 
 module.exports = app;

--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const app = express();
+const PORT = process.env.PORT || 1337;
 
 require('./config/middleware.js')(app, express);
 require('./config/routes.js')(app, express);
 
-app.listen(1337);
-
+app.set('port', PORT);
+app.listen(PORT);
 
 module.exports = app;


### PR DESCRIPTION
#### What's this PR do?
- Sets port dynamically, either based on `process.env` or the default of 1337
- Changes function syntax to ES6 in `middleware.js` and `routes.js`
#### Any background context you want to provide?

n/a
#### What are the relevant tickets/issues?

n/a
#### Where should the reviewer start?

`server/server.js`
#### Are there tests written yet? How should this be manually tested?

n/a
#### Screenshots (if appropriate)
#### Questions:
- Does this add new dependencies?
  No
- Does our documentation need to be updated?
  No
