### PR TITLE
Move destinations object prep to controller

### DIFF
--- a/server/destinations/destinations.js
+++ b/server/destinations/destinations.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const db = require('../config/db');
 const Sequelize = require('sequelize');
 const Trip = require('../trips/trips');
@@ -18,13 +17,8 @@ Trip.hasMany(Destination);
 Destination.sync();
 Trip.sync();
 
-Destination.createDestinations = (destinations, tripId) => {
-  // extend destination objects with tripId from url param
-  const tripIds = Array(destinations.length).fill({ tripId });
-  const newDestinations = _.merge(destinations, tripIds);
-
-  return Destination.bulkCreate(newDestinations).catch(err => err);
-};
+Destination.createDestinations = (destinations) =>
+  Destination.bulkCreate(destinations).catch(err => err);
 
 Destination.getDestinations = tripId =>
   Destination.findAll({ where: { tripId } }).catch(err => err);

--- a/server/destinations/destinationsController.js
+++ b/server/destinations/destinationsController.js
@@ -7,7 +7,11 @@ module.exports = {
   // Params: req.body.destinations is an array of destination objects.
   // Returns: array of created destinations
   createAll: (req, res, next) => {
-    Destination.createDestinations(req.body.destinations, req.params.tripId)
+    // extend destination objects with tripId from url param
+    const tripIds = Array(req.body.destinations.length).fill({ tripId: req.params.tripId });
+    const newDestinations = _.merge(req.body.destinations, tripIds);
+
+    Destination.createDestinations(newDestinations)
       .then(destinations => {
         res.status(201).json(destinations);
       })


### PR DESCRIPTION
#### What's this PR do?
- Moves the addition of tripId to destination objects to the controller. The logic here is that the model should only expect a fully formed destinations object array, for testability. Shout out to @leranf 
#### Any background context you want to provide?

n/a
#### What are the relevant tickets/issues?

n/a
#### Where should the reviewer start?

`destinationController.js`
#### Are there tests written yet? How should this be manually tested?

No
#### Screenshots (if appropriate)
#### Questions:
- Does this add new dependencies?
  No
- Does our documentation need to be updated?
  No
