### PR TITLE
Refactor home components to use react-redux mapDispatchToProps

### DIFF
--- a/client/home/destSearch.js
+++ b/client/home/destSearch.js
@@ -6,18 +6,24 @@ import { changeStartDate, changeEndDate, changeDestination } from './homeActions
 import DatePicker
 from '../../node_modules/material-ui/lib/date-picker/date-picker';
 
-let DestSearch = ({ dispatch }) => (
+const mapDispatchToProps = dispatch => ({
+  onChangeDestination: destination => dispatch(changeDestination(destination)),
+  onChangeStartDate: newStartDate => dispatch(changeStartDate(newStartDate)),
+  onChangeEndDate: newEndDate => dispatch(changeEndDate(newEndDate)),
+});
+
+let DestSearch = ({ onChangeDestination, onChangeStartDate, onChangeEndDate }) => (
   <div>
     <TextField hintText="Enter Destination" onBlur={(event) => {
-      dispatch(changeDestination(event.target.value));
+      onChangeDestination(event.target.value);
     }}
     />
     <DatePicker hintText="Departure Date" onChange={(event, newDate) => {
-      dispatch(changeStartDate(newDate));
+      onChangeStartDate(newDate);
     }}
     />
     <DatePicker hintText="End Date" onChange={(event, newDate) => {
-      dispatch(changeEndDate(newDate));
+      onChangeEndDate(newDate);
     }}
     />
     <RaisedButton label="Add another Destination" secondary href="#" />
@@ -25,8 +31,10 @@ let DestSearch = ({ dispatch }) => (
 );
 
 DestSearch.propTypes = {
-  dispatch: React.PropTypes.element,
+  onChangeDestination: React.PropTypes.func.isRequired,
+  onChangeStartDate: React.PropTypes.func.isRequired,
+  onChangeEndDate: React.PropTypes.func.isRequired,
 };
 
-DestSearch = connect()(DestSearch);
+DestSearch = connect(null, mapDispatchToProps)(DestSearch);
 export default DestSearch;

--- a/client/home/tripTypeList.js
+++ b/client/home/tripTypeList.js
@@ -3,10 +3,14 @@ import { RadioButton, RadioButtonGroup } from 'material-ui';
 import { changeTripType } from './homeActions';
 import { connect } from 'react-redux';
 
-let TripTypeList = ({ dispatch }) => (
+const mapDispatchToProps = dispatch => ({
+  onTripTypeChange: tripType => dispatch(changeTripType(tripType)),
+});
+
+let TripTypeList = ({ onTripTypeChange }) => (
   <div>
     <RadioButtonGroup defaultSelected="Group" onChange={(event, tripType) => {
-      dispatch(changeTripType(tripType));
+      onTripTypeChange(tripType);
     }}
     >
       <RadioButton label="Group" value="Group" />
@@ -17,8 +21,8 @@ let TripTypeList = ({ dispatch }) => (
 );
 
 TripTypeList.propTypes = {
-  dispatch: React.PropTypes.element,
+  onTripTypeChange: React.PropTypes.func.isRequired,
 };
 
-TripTypeList = connect()(TripTypeList);
+TripTypeList = connect(null, mapDispatchToProps)(TripTypeList);
 export default TripTypeList;


### PR DESCRIPTION
#### What's this PR do?
- Factors out dispatch methods to `mapDispatchToProps`, so that the `DestSearch` and `TripTypeList` components only have access to the methods they need
#### Any background context you want to provide?

Follows Redux 'way'. Note that we don't inject state into either component--they are stateless. State is kept track of in the store and within the Material UI components inside our components.
#### What are the relevant tickets/issues?
#### Where should the reviewer start?

`tripTypeList.js`
#### Are there tests written yet? How should this be manually tested?

Go through the first page to select destination dates, location, and trip type.
#### Screenshots (if appropriate)
#### Questions:
- Does this add new dependencies?
  No
- Does our documentation need to be updated?
  No
