### PR TITLE
Disable photos temporarily

### DIFF
--- a/server/events/events.js
+++ b/server/events/events.js
@@ -25,10 +25,10 @@ Event.sync();
 Destination.sync();
 
 Event.createEvents = events =>
-  extendResourceWithPhotos(events)
-    .then(eventsWithPhotos =>
+  // extendResourceWithPhotos(events)
+  //   .then(eventsWithPhotos =>
       Event.bulkCreate(events, { returning: true })
-    )
+    // )
     .catch(err => err);
 
 Event.getEvents = destId => Event.findAll({ where: { destId } })


### PR DESCRIPTION
#### What's this PR do?
- Disables flickr photo extension due to bug in displaying events on tripOverview
#### Any background context you want to provide?
#### What are the relevant tickets/issues?
#### Where should the reviewer start?
#### Are there tests written yet? How should this be manually tested?
#### Screenshots (if appropriate)
#### Questions:
- Does this add new dependencies?
- Does our documentation need to be updated?
