### PR TITLE
Start server with forever, redis automatically started

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Group travel made easy",
   "main": "webpack.config.js",
   "scripts": {
-    "start":"forever start redis-server && forever start server/server.js",
+    "start":"forever start server/server.js",
     "test": "karma start && mocha server/__tests__/.",
     "lint": "eslint .",
     "validate": "npm ls"


### PR DESCRIPTION
#### What's this PR do?

Not much--`npm start` just runs `forever start server/server.js`. We can use this in deployment. I manually changed settings on our deployed instance to run Redis automatically in the background, and start when the server boots up. We can test this tomorrow to make sure it's actually running in the background.
#### Any background context you want to provide?
#### What are the relevant tickets/issues?
#### Where should the reviewer start?
#### Are there tests written yet? How should this be manually tested?
#### Screenshots (if appropriate)
#### Questions:
- Does this add new dependencies?
- Does our documentation need to be updated?
