### PR TITLE
Gridlist clickable, adjust buttons and cards

### DIFF
--- a/client/friend/friendItem.js
+++ b/client/friend/friendItem.js
@@ -5,7 +5,7 @@ import Card from 'material-ui/lib/card/card';
 import CardHeader from 'material-ui/lib/card/card-header';
 
 const FriendItem = ({ key, name, picUrl, addedToTrip, onClick }) => (
-   <Card style={ { width: '90%', margin: '0% 5%' } }>
+   <Card>
     <CardHeader
       title={name}
       avatar={picUrl}
@@ -26,3 +26,4 @@ FriendItem.propTypes = {
 };
 
 export default FriendItem;
+// style={ { width: '90%', margin: '0% 5%' } }

--- a/client/friend/friendItem.js
+++ b/client/friend/friendItem.js
@@ -26,4 +26,3 @@ FriendItem.propTypes = {
 };
 
 export default FriendItem;
-// style={ { width: '90%', margin: '0% 5%' } }

--- a/client/friend/friendList.js
+++ b/client/friend/friendList.js
@@ -30,9 +30,11 @@ let FriendList = ({ friends, onFriendClick }) => (
           <FriendItem key={ friend.id } {...friend} onClick={() => onFriendClick(friend.id)} />
         )}
       </List>
-      <Link to="home"><RaisedButton label="Back" /></Link>
+      <Link to="home">
+        <RaisedButton label="Back" style={{ marginTop: '16px' }} />
+      </Link>
       <Link to="tag">
-        <RaisedButton secondary label="Next" style={ { float: 'right' } } />
+        <RaisedButton secondary label="Next" style={ { float: 'right', marginTop: '16px' } } />
       </Link>
     </Card>
   </div>

--- a/client/friend/friendList.js
+++ b/client/friend/friendList.js
@@ -18,7 +18,7 @@ const mapDispatchToProps = dispatch => ({
 
 let FriendList = ({ friends, onFriendClick }) => (
   <div>
-    <Card style={ { width: '60%', margin: '5% 20%' } }>
+    <Card style={ { width: '60%', margin: '5% 20%', padding: '1.5%' } }>
       <CardHeader
         title={
           friends.length ? 'Choose the friends you want to travel with!' :

--- a/client/query/queryList.js
+++ b/client/query/queryList.js
@@ -51,37 +51,48 @@ let QueryList = ({ destinations, tripType, onClickSave, friends, events, onClick
         backgroundColor: 'transparent',
       }}
     />
-  <Card style={ { width: '60%', margin: '5% 20%', visibility: loading ? 'hidden' : 'visible' } }>
-    <CardHeader
-      title={destinations.getIn([currPage, 'location'])}
-      subtitle = {'Choose the places you want to go!'}
-    />
-      <List style={ { visibility: loading ? 'hidden' : 'visible' } }>
-        { events[currPage].map(event =>
-          <QueryItem key={ event.id } { ...event }
-            eventToggle={ () => onClickToggle(event) }
-            style={{
-              visibility: loading ? 'hidden' : 'visible',
-            }}
-          />
-        )}
-    </List>
-    <Link to="tag"><RaisedButton label="Back" /></Link>
-    <RaisedButton secondary label="Next" style={ { float: 'right' } } onMouseDown={ () => {
-      if (trip.id === undefined) {
-        onNextQuery();
-        if (currPage === destinations.length - 1) {
-          goStartLoad();
-          onClickSave(destinations, tripType, friends, events, goNext);
-          onClickReset();
-        }
-      } else {
-        goStartLoad();
-        onClickUpdate(events, dest, goNext, destId);
-      }
-      setTimeout(goEndLoad, 4000);
+    <Card style={{
+      width: '60%',
+      margin: '5% 20%',
+      visibility: loading ? 'hidden' : 'visible',
+      padding: '1.5%',
     }}
-    />
+    >
+      <CardHeader
+        title={destinations.getIn([currPage, 'location'])}
+        subtitle = {'Choose the places you want to go!'}
+      />
+        <List style={ { visibility: loading ? 'hidden' : 'visible' } }>
+          { events[currPage].map(event =>
+            <QueryItem key={ event.id } { ...event }
+              eventToggle={ () => onClickToggle(event) }
+              style={{
+                visibility: loading ? 'hidden' : 'visible',
+              }}
+            />
+          )}
+      </List>
+      <Link to="tag">
+        <RaisedButton label="Back" style={ { marginTop: '16px' } } />
+      </Link>
+      <RaisedButton secondary
+        label="Next"
+        style={ { float: 'right', marginTop: '16px' } }
+        onMouseDown={ () => {
+          if (trip.id === undefined) {
+            onNextQuery();
+            if (currPage === destinations.length - 1) {
+              goStartLoad();
+              onClickSave(destinations, tripType, friends, events, goNext);
+              onClickReset();
+            }
+          } else {
+            goStartLoad();
+            onClickUpdate(events, dest, goNext, destId);
+          }
+          setTimeout(goEndLoad, 4000);
+        }}
+      />
     </Card>
   </div>
 );

--- a/client/tag/tagList.js
+++ b/client/tag/tagList.js
@@ -8,7 +8,11 @@ import { startSearch } from '../query/queryActions';
 import { push } from 'react-router-redux';
 import GridList from 'material-ui/lib/grid-list/grid-list';
 import GridTile from 'material-ui/lib/grid-list/grid-tile';
+import ActionFavorite from 'material-ui/lib/svg-icons/action/favorite';
+import ActionFavoriteBorder from 'material-ui/lib/svg-icons/action/favorite-border';
 import { RaisedButton } from 'material-ui';
+import Card from 'material-ui/lib/card/card';
+import CardHeader from 'material-ui/lib/card/card-header';
 
 const mapStateToProps = state => ({
   tags: state.tag.get('tags'),
@@ -47,42 +51,50 @@ let TagList = ({ onToggleTag, onStartSearch, goNext, tags, destinations, chosen,
         visibility: loading ? 'visible' : 'hidden',
       }}
     />
-    <GridList
-      cellHeight={200}
-      style={{
-        width: '60%',
-        height: '100%',
-        overflowY: 'auto',
-        margin: '5% 20%',
-        visibility: loading ? 'hidden' : 'visible',
-      }}
-    >
-      {tags.map(tag => (
-        <GridTile
-          key={tag.img}
-          title={tag.name}
-          actionIcon=
-            {<IconButton onClick={() => onToggleTag(tag.name)}>
-              <StarBorder color="white" />
-            </IconButton>}
-          actionPosition={tag.addedToTrip ? 'left' : 'right'}
-        >
-          <img src={tag.img} style={ { width: '100%', height: '100%' } } />
-        </GridTile>
-      ))}
-    <Link to="friend"><RaisedButton label="Back" /></Link>
-    <RaisedButton secondary label="Next" style={ { float: 'right' } } onMouseDown={ () => {
-      startLoadEvents();
-      if (chosen.size === 0) {
-        onStartSearch(goNext, tags, destinations, currPage)
-        .then(() => endLoadEvents());
-      } else {
-        onStartSearch(goNext, tags, [chosen[destId]], 0, destId)
-        .then(() => endLoadEvents());
-      }
-    }}
-    />
-    </GridList>
+    <Card style={ { width: '60%', margin: '5% 20%', padding: '1.5%' } }>
+      <CardHeader
+        title={'Sightseeing, relaxation, adventure...choose a few tags below, and we\'ll suggest places you\'ll love!'} // eslint-disable-line
+      />
+      <GridList
+        cellHeight={200}
+        style={{
+          visibility: loading ? 'hidden' : 'visible',
+        }}
+      >
+        {tags.map(tag => (
+          <GridTile
+            key={tag.img}
+            title={tag.name}
+            actionIcon=
+              {<IconButton onClick={() => onToggleTag(tag.name)}>
+                {tag.addedToTrip ?
+                  <ActionFavorite color={ loading ? 'white' : '#00bcd4' } /> :
+                  <ActionFavoriteBorder color="white" />
+                }
+              </IconButton>}
+          >
+            <img src={tag.img} style={ { width: '100%', height: '100%' } } />
+          </GridTile>
+        ))}
+      </GridList>
+      <Link to="friend">
+        <RaisedButton label="Back"
+          style={{ visibility: loading ? 'hidden' : 'visible', marginTop: '16px' }}
+        />
+      </Link>
+      <RaisedButton secondary label="Next" style={ { float: 'right', marginTop: '16px' } }
+        onMouseDown={ () => {
+          startLoadEvents();
+          if (chosen.size === 0) {
+            onStartSearch(goNext, tags, destinations, currPage)
+            .then(() => endLoadEvents());
+          } else {
+            onStartSearch(goNext, tags, [chosen[destId]], 0, destId)
+            .then(() => endLoadEvents());
+          }
+        }}
+      />
+    </Card>
   </div>
 );
 


### PR DESCRIPTION
#### What's this PR do?
- Makes the gridlist of tags clickable with the heart filling in blue
- Adjust 'Back' and 'Next' buttons to have some spacing
- Also adds a title/instructions to the tags page
#### Any background context you want to provide?
#### What are the relevant tickets/issues?

Closes #155 
#### Where should the reviewer start?

`tagList.js`
#### Are there tests written yet? How should this be manually tested?
#### Screenshots (if appropriate)

<img width="936" alt="screen shot 2016-04-01 at 12 15 54 pm" src="https://cloud.githubusercontent.com/assets/4003102/14217540/85507586-f803-11e5-8f2d-f175eb072365.png">
<img width="861" alt="screen shot 2016-04-01 at 12 16 20 pm" src="https://cloud.githubusercontent.com/assets/4003102/14217558/92b3d8a8-f803-11e5-86aa-5b762a1a7f66.png">
<img width="905" alt="screen shot 2016-04-01 at 12 16 39 pm" src="https://cloud.githubusercontent.com/assets/4003102/14217565/9eba07da-f803-11e5-9066-d771740e9544.png">
<img width="830" alt="screen shot 2016-04-01 at 12 16 58 pm" src="https://cloud.githubusercontent.com/assets/4003102/14217567/ab3f8f2a-f803-11e5-892d-419ca24eac3b.png">
#### Questions:
- Does this add new dependencies?
- Does our documentation need to be updated?
